### PR TITLE
conda-package-streaming 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "conda-package-streaming" %}
-{% set version = "0.8.0" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/conda/conda-package-streaming/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 5e5212153e285a48223c70ede741d00304725a11cb690c494464a12f04c607f5
+  url: https://github.com/conda/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: a454def50ab1b69b267c15ef5d97f3b7f492b643694d289d3a9231e8aeaf8943
 
 build:
   number: 0
@@ -19,7 +19,6 @@ requirements:
     - flit-core
     - python
     - pip
-    - wheel
   run:
     - python
     - zstandard >=0.15
@@ -49,3 +48,5 @@ about:
 extra:
   recipe-maintainers:
     - dholth
+  skip-lints:
+    - missing_wheel


### PR DESCRIPTION
Changelog: https://github.com/conda/conda-package-streaming/blob/v0.9.0/CHANGELOG.md
Requirements: https://github.com/conda/conda-package-streaming/blob/v0.9.0/pyproject.toml

Actions:
1. Remove `wheel` from `host` as `flit-core` has its own wheel builder https://github.com/pypa/flit/blob/f7496a50debdfa393e39f8e51d328deabcd7ae7e/flit_core/flit_core/wheel.py#L61
2. Skip `missing_wheel` lint
