### PR TITLE
conda-package-streaming 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-package-streaming" %}
-{% set version = "0.12.0" %}
+{% set version = "0.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2cd261d3bc3bd4c51e2bb84a8397b6cc1b591f837838439d4befc12fc3d77314
+  sha256: a58868bedb6231485008c6fef0326900cd6fab51b6ed9942457100836c5c8588
 
 build:
-  number: 1
-  skip: true  # [py<39]
+  number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - pip
   run:
     - python
-    - zstandard >=0.15
+    - backports.zstd  # [py<314]
     - requests
 
 test:


### PR DESCRIPTION
## conda-package-streaming 0.13.0

**Destination channel:** defaults

### Links
- [PKG-15335](https://anaconda.atlassian.net/browse/PKG-15335)
- [GitHub Release](https://github.com/conda/conda-package-streaming/releases/tag/v0.13.0)

### Explanation of changes:
- Updated conda-package-streaming from 0.12.0 to 0.13.0
- Replaced `zstandard` dep with `backports.zstd` (for py<3.14; py3.14+ uses stdlib `compression.zstd`)
- Minimum Python version bumped from 3.9 to 3.10
- Accept pre-opened `ZipFile` via `zf=` kwarg on `stream_conda_component`

[PKG-15335]: https://anaconda.atlassian.net/browse/PKG-15335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ